### PR TITLE
Replace Content API with sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # GOV.UK: Seed the Crawler
 
-This gem retrieves a list of seed URLs from the GOV.UK content API and adds them to RabbitMQ
+This gem retrieves a list of seed URLs from the GOV.UK sitemap and adds them to RabbitMQ
 so that the [crawler](https://github.com/alphagov/govuk_crawler_worker) can consume them.
-
-It depends on the `govuk_mirrorer` gem for parsing the response from the content API.
-Once this dependency is removed the `govuk_mirrorer` gem can be archived.
 
 ## Installation
 

--- a/govuk_seed_crawler.gemspec
+++ b/govuk_seed_crawler.gemspec
@@ -6,10 +6,10 @@ require 'govuk_seed_crawler/version'
 Gem::Specification.new do |spec|
   spec.name          = "govuk_seed_crawler"
   spec.version       = GovukSeedCrawler::VERSION
-  spec.authors       = ["Matt Bostock"]
-  spec.email         = ["matt.bostock@digital.cabinet-office.gov.uk"]
+  spec.authors       = ['GOV.UK developers']
+  spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
   spec.summary       = %q{Retrieves a list of URLs to seed the crawler by publishing them to a RabbitMQ exchange.}
-  spec.homepage      = "https://github.gds/gds/govuk_seed_crawler"
+  spec.homepage      = "https://github.com/alphagov/govuk_seed_crawler"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")

--- a/govuk_seed_crawler.gemspec
+++ b/govuk_seed_crawler.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "bunny", "~> 1.3"
-  spec.add_runtime_dependency "govuk_mirrorer", "~> 1.3.1"
+  spec.add_runtime_dependency "sitemap-parser", "~> 0.3.0"
   spec.add_runtime_dependency "slop", "~> 3.6.0"
 
   spec.add_development_dependency "gem_publisher", "~> 1.3"

--- a/jenkins-branches.sh
+++ b/jenkins-branches.sh
@@ -6,7 +6,7 @@ set -e
 
 pip install -q ghtools
 
-REPO="gds:gds/govuk_seed_crawler"
+REPO="alphagov/govuk_seed_crawler"
 gh-status "$REPO" "$GIT_COMMIT" pending -d "\"Build #${BUILD_NUMBER} is running on Jenkins\"" -u "$BUILD_URL" >/dev/null
 
 if ./jenkins-tests.sh; then

--- a/lib/govuk_seed_crawler/indexer.rb
+++ b/lib/govuk_seed_crawler/indexer.rb
@@ -1,5 +1,4 @@
-require 'govuk_mirrorer/indexer'
-require 'govuk_mirrorer/statsd'
+require 'sitemap-parser'
 
 module GovukSeedCrawler
   class Indexer
@@ -9,8 +8,9 @@ module GovukSeedCrawler
       raise "No site_root defined" unless site_root
 
       GovukSeedCrawler.logger.info("Retrieving list of URLs for #{site_root}")
-      indexer = GovukMirrorer::Indexer.new(site_root)
-      @urls = indexer.all_start_urls
+
+      sitemap = SitemapParser.new("#{site_root}/sitemap.xml", {recurse: true})
+      @urls = sitemap.to_a
 
       GovukSeedCrawler.logger.info("Found #{@urls.count} URLs")
     end

--- a/lib/govuk_seed_crawler/version.rb
+++ b/lib/govuk_seed_crawler/version.rb
@@ -1,3 +1,3 @@
 module GovukSeedCrawler
-  VERSION = "1.0.0"
+  VERSION = "2.0.0"
 end

--- a/spec/govuk_seed_crawler/indexer_spec.rb
+++ b/spec/govuk_seed_crawler/indexer_spec.rb
@@ -1,20 +1,20 @@
 require 'spec_helper'
 
 describe GovukSeedCrawler::Indexer do
-  subject { GovukSeedCrawler::Indexer.new('https://example.com/') }
+  subject { GovukSeedCrawler::Indexer.new('https://example.com') }
 
   context "under normal usage" do
-    let(:mock_indexer) do
-      double(:mock_indexer, :all_start_urls => [])
+    let(:mock_parser) do
+      double(:mock_parser, :to_a => [])
     end
 
     it "responds to Indexer#urls" do
-      allow(GovukMirrorer::Indexer).to receive(:new).and_return(mock_indexer)
+      allow(SitemapParser).to receive(:new).and_return(mock_parser)
       expect(subject).to respond_to(:urls)
     end
 
-    it "calls GovukMirrorer::Indexer with the site root" do
-      expect(GovukMirrorer::Indexer).to receive(:new).with('https://example.com/').and_return(mock_indexer)
+    it "calls SitemapParser with the sitemap file" do
+      expect(SitemapParser).to receive(:new).with('https://example.com/sitemap.xml', {:recurse => true}).and_return(mock_parser)
       subject
     end
   end


### PR DESCRIPTION
This needs the `sitemap-parser` gem to be bumped to an as-yet unreleased version.
