### PR TITLE
Lock nokogiri to ~> 1.6.0

### DIFF
--- a/govuk_seed_crawler.gemspec
+++ b/govuk_seed_crawler.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "bunny", "~> 1.3"
+  spec.add_runtime_dependency "nokogiri", "~> 1.6.0"
   spec.add_runtime_dependency "sitemap-parser", "~> 0.3.0"
   spec.add_runtime_dependency "slop", "~> 3.6.0"
 

--- a/lib/govuk_seed_crawler/version.rb
+++ b/lib/govuk_seed_crawler/version.rb
@@ -1,3 +1,3 @@
 module GovukSeedCrawler
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
The seed crawler needs to run on machines with only ruby 1.9.3 installed
on them. This is a too low version of ruby for nokogiri 1.8 (the
current). This locks nokogiri to the last known good version for use
with ruby 1.9.3 & bumps the version number to 2.0.1