### PR TITLE
Fix the version of public_suffix to ~1.4.6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,16 +21,7 @@ node {
     }
 
     stage('Bundle install') {
-
-      echo 'Bundling'
-      govuk.withStatsdTiming("bundle") {
-        lock ("bundle_install-$NODE_NAME") {
-          // This is a copy of the bundleGem method in the govuk library
-          // but we change the `--path` to be in the work directory so that
-          // we don't have problems trying to use too-new versions of gems.
-          sh("bundle install --path bundles")
-        }
-      }
+      govuk.bundleGem()
     }
 
     stage('Spec tests') {

--- a/govuk_seed_crawler.gemspec
+++ b/govuk_seed_crawler.gemspec
@@ -19,6 +19,9 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "bunny", "~> 1.3"
   spec.add_runtime_dependency "nokogiri", "~> 1.6.0"
+  # Something, somewhere, sometimes requires public_suffix.
+  # public_suffix > 1.5 requires ruby > 2.
+  spec.add_runtime_dependency "public_suffix", "~> 1.4.6"
   spec.add_runtime_dependency "sitemap-parser", "~> 0.3.0"
   spec.add_runtime_dependency "slop", "~> 3.6.0"
 


### PR DESCRIPTION
Something (I can't find what) seems to want to install public_suffix in
some circumstance (e.g. on Jenkins but not locally). public_suffix
requires ruby > 2 and will throw an error on older versions (i.e.
1.9.3). As we can't easily upgrade the version of ruby this instead
locks the version of public_suffix.