### PR TITLE
Ensure this can be installed in Ruby 1.9.3

### DIFF
--- a/govuk_seed_crawler.gemspec
+++ b/govuk_seed_crawler.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "bunny", "~> 1.3"
+  spec.add_runtime_dependency "ffi", "1.10.0"
   spec.add_runtime_dependency "nokogiri", "~> 1.6.0"
   # Something, somewhere, sometimes requires public_suffix.
   # public_suffix > 1.5 requires ruby > 2.

--- a/govuk_seed_crawler.gemspec
+++ b/govuk_seed_crawler.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "bunny", "~> 1.3"
+  spec.add_runtime_dependency "crack", "0.4.4"
   spec.add_runtime_dependency "ffi", "1.10.0"
   spec.add_runtime_dependency "nokogiri", "~> 1.6.0"
   # Something, somewhere, sometimes requires public_suffix.

--- a/lib/govuk_seed_crawler/version.rb
+++ b/lib/govuk_seed_crawler/version.rb
@@ -1,3 +1,3 @@
 module GovukSeedCrawler
-  VERSION = "2.0.1"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
We `govuk_seed_crawler` in Ruby 1.9.3 which is no longer supported. At the moment we're experiencing a problem where the Gem can't be installed on the machines because some indirect dependencies have stopped support Ruby 1.9.3. I hope that by being more explicit on the versions, we can avoid this happening in the future, at least while we still use Ruby 1.9.3.

It looks like https://github.com/alphagov/govuk-puppet/commit/3485b4632046440d0d5f399d40fa3aa8b0757f3b was an attempt to fix this, but it doesn't seem to have worked completely.

See individual commits for more details.