### PR TITLE
Fix gem publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ node {
 
     if (env.BRANCH_NAME == 'master') {
       stage('Publish Gem to Rubygems') {
-        govuk.publishGem(repoName, 'master')
+        govuk.publishGem(repoName, repoName, 'master')
       }
     }
   } catch (e) {


### PR DESCRIPTION
The [method signature of publishGem changed](https://github.com/alphagov/govuk-jenkinslib/commit/901dd395fab1eed5b4dd52c568561734798d36b4) a while ago to allow the use of a name that wasn't the same as this repo (thus breaking this part of the build).

This gem doesn't use the standard [`buildProject`](https://github.com/alphagov/govuk-jenkinslib/blob/main/vars/govuk.groovy#L3) route because it relies on some old things which are more easily managed in isolation rather than trying to make `buildProject` cater for every special thing.

The gem is currently [failing to publish](https://ci.integration.publishing.service.gov.uk/job/govuk_seed_crawler/job/master/3/console)

This needs to be fixed in order to fix [puppet errors](https://alert.production.govuk.digital/cgi-bin/icinga/extinfo.cgi?type=2&host=ip-10-13-6-172.eu-west-1.compute.internal&service=puppet+last+run+errors) on a mirrorer machine.

> Error: Could not update: Execution of '/usr/bin/gem install -v 2.1.0 --no-rdoc --no-ri govuk_seed_crawler' returned 2: ERROR:  Could not find a valid gem 'govuk_seed_crawler' (= 2.1.0) in any repository
> ERROR:  Possible alternatives: govuk_seed_crawler
> Error: /Stage[main]/Govuk_crawler/Package[govuk_seed_crawler]/ensure: change from ["2.0.1"] to 2.1.0 failed: Could not update: Execution of '/usr/bin/gem install -v 2.1.0 --no-rdoc --no-ri govuk_seed_crawler' returned 2: ERROR:  Could not find a valid gem 'govuk_seed_crawler' (= 2.1.0) in any repository
> ERROR:  Possible alternatives: govuk_seed_crawler
> Notice: Finished catalog run in 58.80 seconds

Those errors are because the required version of the gem is not yet in rubygems.