### PR TITLE
Some TLC before switch to GitHub Actions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,19 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rake.yml
+    - config/rspec.yml
+
+inherit_mode:
+  merge:
+    - Exclude
+
+# **************************************************************
+# TRY NOT TO ADD OVERRIDES IN THIS FILE
+#
+# This repo is configured to follow the RuboCop GOV.UK styleguide.
+# Any rules you override here will cause this repo to diverge from
+# the way we write code in all other GOV.UK repos.
+#
+# See https://github.com/alphagov/rubocop-govuk/blob/main/CONTRIBUTING.md
+# **************************************************************

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+- We use the [GOV.UK versioning guidelines](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#versioning).
+- Mark breaking changes with `BREAKING:`. Be sure to include instructions on how applications should be upgraded.
+- Don't include changes that are purely internal. The CHANGELOG should be a
+  useful summary for people upgrading their application, not a replication
+  of the commit log.
+
+## Unreleased
+
+- Drop support for Ruby < 2.7

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in govuk_seed_crawler.gemspec
 gemspec

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,10 +17,6 @@ node {
       govuk.cleanupGit()
     }
 
-    stage('Configure environment') {
-      govuk.setEnvar('RBENV_VERSION', '2.6.3')
-    }
-
     stage('Bundle install') {
       govuk.bundleGem()
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,12 +21,8 @@ node {
       govuk.bundleGem()
     }
 
-    stage('Spec tests') {
-      govuk.runRakeTask('spec')
-    }
-
-    stage('Integration tests') {
-      govuk.runRakeTask('integration')
+    stage('Run tests') {
+      govuk.runRakeTask('default')
     }
 
     if (env.BRANCH_NAME == 'main') {

--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
-(c) 2014 Crown copyright
+The MIT License (MIT)
 
-MIT License
+Copyright (C) 2014 Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ bundle exec seed-crawler --help
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
+
+## Licence
+
+[MIT License](LICENCE)

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,7 @@
 require "rspec/core/rake_task"
+require "rubocop/rake_task"
 
-RSpec::Core::RakeTask.new(:spec) do |task|
-  task.pattern = FileList["spec/govuk_seed_crawler/**/*_spec.rb"]
-end
+RSpec::Core::RakeTask.new(:spec)
+RuboCop::RakeTask.new
 
-RSpec::Core::RakeTask.new(:integration) do |task|
-  task.pattern = FileList["spec/integration/**/*_spec.rb"]
-end
-
-task default: :spec
+task default: %i[rubocop spec]

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,11 @@
-require 'rspec/core/rake_task'
+require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec) do |task|
-  task.pattern = FileList['spec/govuk_seed_crawler/**/*_spec.rb']
+  task.pattern = FileList["spec/govuk_seed_crawler/**/*_spec.rb"]
 end
 
 RSpec::Core::RakeTask.new(:integration) do |task|
-  task.pattern = FileList['spec/integration/**/*_spec.rb']
+  task.pattern = FileList["spec/integration/**/*_spec.rb"]
 end
 
-task :default => :spec
+task default: :spec

--- a/govuk_seed_crawler.gemspec
+++ b/govuk_seed_crawler.gemspec
@@ -32,5 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-mocks", "~> 3.0"
+  spec.add_development_dependency "rubocop-govuk", "4.7.0"
   spec.add_development_dependency "webmock", "~> 3.18"
 end

--- a/govuk_seed_crawler.gemspec
+++ b/govuk_seed_crawler.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "slop", "~> 3.6.0"
 
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-mocks", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 3.18"

--- a/govuk_seed_crawler.gemspec
+++ b/govuk_seed_crawler.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-mocks", "~> 3.0"
-  spec.add_development_dependency "webmock", "~> 3.18.1"
+  spec.add_development_dependency "webmock", "~> 3.18"
 end

--- a/govuk_seed_crawler.gemspec
+++ b/govuk_seed_crawler.gemspec
@@ -1,14 +1,13 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'govuk_seed_crawler/version'
+require "govuk_seed_crawler/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "govuk_seed_crawler"
   spec.version       = GovukSeedCrawler::VERSION
-  spec.authors       = ['GOV.UK developers']
+  spec.authors       = ["GOV.UK developers"]
   spec.email         = ["govuk-dev@digital.cabinet-office.gov.uk"]
-  spec.summary       = %q{Retrieves a list of URLs to seed the crawler by publishing them to a RabbitMQ exchange.}
+  spec.summary       = "Retrieves a list of URLs to seed the crawler by publishing them to a RabbitMQ exchange."
   spec.homepage      = "https://github.com/alphagov/govuk_seed_crawler"
   spec.license       = "MIT"
 
@@ -17,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = %w[lib]
 
   spec.add_runtime_dependency "bunny", ">= 1.3", "< 3.0"
   spec.add_runtime_dependency "crack", "0.4.5"

--- a/govuk_seed_crawler.gemspec
+++ b/govuk_seed_crawler.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/alphagov/govuk_seed_crawler"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = "~> 2.6"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/lib/govuk_seed_crawler.rb
+++ b/lib/govuk_seed_crawler.rb
@@ -6,12 +6,16 @@ require "govuk_seed_crawler/seeder"
 require "govuk_seed_crawler/version"
 
 module GovukSeedCrawler
-  def self.logger
-    unless @logger
-      @logger = Logger.new($stdout)
-      @logger.level = Logger::INFO
-    end
+  class << self
+    attr_writer :logger
 
-    @logger
+    def logger
+      unless @logger
+        @logger = Logger.new($stdout)
+        @logger.level = Logger::INFO
+      end
+
+      @logger
+    end
   end
 end

--- a/lib/govuk_seed_crawler.rb
+++ b/lib/govuk_seed_crawler.rb
@@ -1,14 +1,14 @@
-require 'govuk_seed_crawler/amqp_client'
-require 'govuk_seed_crawler/cli_parser'
-require 'govuk_seed_crawler/cli_runner'
-require 'govuk_seed_crawler/indexer'
-require 'govuk_seed_crawler/seeder'
-require 'govuk_seed_crawler/version'
+require "govuk_seed_crawler/amqp_client"
+require "govuk_seed_crawler/cli_parser"
+require "govuk_seed_crawler/cli_runner"
+require "govuk_seed_crawler/indexer"
+require "govuk_seed_crawler/seeder"
+require "govuk_seed_crawler/version"
 
 module GovukSeedCrawler
   def self.logger
     unless @logger
-      @logger = Logger.new(STDOUT)
+      @logger = Logger.new($stdout)
       @logger.level = Logger::INFO
     end
 

--- a/lib/govuk_seed_crawler/amqp_client.rb
+++ b/lib/govuk_seed_crawler/amqp_client.rb
@@ -1,4 +1,4 @@
-require 'bunny'
+require "bunny"
 
 module GovukSeedCrawler
   class AmqpClient
@@ -21,8 +21,8 @@ module GovukSeedCrawler
 
       GovukSeedCrawler.logger.debug("Publishing '#{body}' to topic '#{topic}'")
 
-      @channel.topic(exchange, :durable => true)
-        .publish(body, :routing_key => topic)
+      @channel.topic(exchange, durable: true)
+        .publish(body, routing_key: topic)
     end
   end
 end

--- a/lib/govuk_seed_crawler/cli_parser.rb
+++ b/lib/govuk_seed_crawler/cli_parser.rb
@@ -1,4 +1,4 @@
-require 'slop'
+require "slop"
 
 module GovukSeedCrawler
   class CLIException < StandardError
@@ -12,17 +12,17 @@ module GovukSeedCrawler
 
   class CLIParser
     DEFAULTS = {
-      :exchange => "govuk_crawler_exchange",
-      :help => nil,
-      :host => "localhost",
-      :password => "guest",
-      :port => "5672",
-      :quiet => false,
-      :topic => "#",
-      :username => "guest",
-      :verbose => false,
-      :version => nil,
-      :vhost => "/"
+      exchange: "govuk_crawler_exchange",
+      help: nil,
+      host: "localhost",
+      password: "guest",
+      port: "5672",
+      quiet: false,
+      topic: "#",
+      username: "guest",
+      verbose: false,
+      version: nil,
+      vhost: "/",
     }.freeze
 
     ENV_AMQP_PASS_KEY = "GOVUK_CRAWLER_AMQP_PASS".freeze
@@ -32,18 +32,18 @@ module GovukSeedCrawler
     end
 
     def options
-      Slop.parse!(@argv_array, :help => true) do
-        banner <<-EOS
-Usage: #{$PROGRAM_NAME} site_root [options]
+      Slop.parse!(@argv_array, help: true) do
+        banner <<~EOS
+          Usage: #{$PROGRAM_NAME} site_root [options]
 
-Seeds an AMQP topic exchange with messages, each containing a URL, for the GOV.UK Crawler Worker
-to consume:
+          Seeds an AMQP topic exchange with messages, each containing a URL, for the GOV.UK Crawler Worker
+          to consume:
 
-https://github.com/alphagov/govuk_crawler_worker
+          https://github.com/alphagov/govuk_crawler_worker
 
-The AMQP password can also be set as an environment variable and will be read from
-`#{ENV_AMQP_PASS_KEY}`. If both the environment variable and command-line option for password
-are set, the environment variable will take higher precedent.
+          The AMQP password can also be set as an environment variable and will be read from
+          `#{ENV_AMQP_PASS_KEY}`. If both the environment variable and command-line option for password
+          are set, the environment variable will take higher precedent.
         EOS
 
         on :version, "Display version and exit" do
@@ -75,7 +75,7 @@ are set, the environment variable will take higher precedent.
       options_hash = opts.to_hash
       options_hash[:password] = ENV[ENV_AMQP_PASS_KEY] unless ENV[ENV_AMQP_PASS_KEY].nil?
 
-      return options_hash, @argv_array.first
+      [options_hash, @argv_array.first]
     end
   end
 end

--- a/lib/govuk_seed_crawler/cli_parser.rb
+++ b/lib/govuk_seed_crawler/cli_parser.rb
@@ -33,7 +33,7 @@ module GovukSeedCrawler
 
     def options
       Slop.parse!(@argv_array, help: true) do
-        banner <<~EOS
+        banner <<~HELP
           Usage: #{$PROGRAM_NAME} site_root [options]
 
           Seeds an AMQP topic exchange with messages, each containing a URL, for the GOV.UK Crawler Worker
@@ -44,7 +44,7 @@ module GovukSeedCrawler
           The AMQP password can also be set as an environment variable and will be read from
           `#{ENV_AMQP_PASS_KEY}`. If both the environment variable and command-line option for password
           are set, the environment variable will take higher precedent.
-        EOS
+        HELP
 
         on :version, "Display version and exit" do
           puts "Version: #{GovukSeedCrawler::VERSION}"

--- a/lib/govuk_seed_crawler/cli_runner.rb
+++ b/lib/govuk_seed_crawler/cli_runner.rb
@@ -13,10 +13,10 @@ module GovukSeedCrawler
     end
 
     def run
-      Seeder::seed(@site_root, @options)
+      Seeder.seed(@site_root, @options)
     end
 
-    private
+  private
 
     def set_logging_level(cli_options)
       if cli_options[:verbose]

--- a/lib/govuk_seed_crawler/indexer.rb
+++ b/lib/govuk_seed_crawler/indexer.rb
@@ -1,4 +1,4 @@
-require 'sitemap-parser'
+require "sitemap-parser"
 
 module GovukSeedCrawler
   class Indexer
@@ -9,7 +9,7 @@ module GovukSeedCrawler
 
       GovukSeedCrawler.logger.info("Retrieving list of URLs for #{site_root}")
 
-      sitemap = SitemapParser.new("#{site_root}/sitemap.xml", {recurse: true})
+      sitemap = SitemapParser.new("#{site_root}/sitemap.xml", { recurse: true })
       @urls = sitemap.to_a
 
       GovukSeedCrawler.logger.info("Found #{@urls.count} URLs")

--- a/lib/govuk_seed_crawler/version.rb
+++ b/lib/govuk_seed_crawler/version.rb
@@ -1,3 +1,3 @@
 module GovukSeedCrawler
-  VERSION = "3.0.0"
+  VERSION = "3.0.0".freeze
 end

--- a/spec/govuk_seed_crawler/amqp_client_spec.rb
+++ b/spec/govuk_seed_crawler/amqp_client_spec.rb
@@ -19,8 +19,10 @@ describe GovukSeedCrawler::AmqpClient do
   end
 
   it "closes the connection to the AMQP server" do
-    mock_bunny = double(:mock_bunny,
-                        start: true, create_channel: true, close: true)
+    mock_bunny = instance_double(Bunny::Session,
+                                 start: true,
+                                 create_channel: true,
+                                 close: true)
     allow(Bunny).to receive(:new).and_return(mock_bunny)
     expect(mock_bunny).to receive(:close).once
 

--- a/spec/govuk_seed_crawler/amqp_client_spec.rb
+++ b/spec/govuk_seed_crawler/amqp_client_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe GovukSeedCrawler::AmqpClient do
-  subject { described_class.new(options) }
-
   let(:exchange) { "govuk_seed_crawler_spec_exchange" }
   let(:options) do
     {
@@ -13,11 +11,11 @@ describe GovukSeedCrawler::AmqpClient do
   end
 
   it "responds to #channel" do
-    expect(subject).to respond_to(:channel)
+    expect(described_class.new(options)).to respond_to(:channel)
   end
 
   it "responds to #close" do
-    expect(subject).to respond_to(:close)
+    expect(described_class.new(options)).to respond_to(:close)
   end
 
   it "closes the connection to the AMQP server" do
@@ -26,32 +24,32 @@ describe GovukSeedCrawler::AmqpClient do
     allow(Bunny).to receive(:new).and_return(mock_bunny)
     expect(mock_bunny).to receive(:close).once
 
-    subject.close
+    described_class.new(options).close
   end
 
   describe "#publish" do
     context "error handling" do
       it "raises an exception if exchange is nil" do
         expect {
-          subject.publish(nil, "#", "some body")
+          described_class.new(options).publish(nil, "#", "some body")
         }.to raise_exception(RuntimeError, "Exchange cannot be nil")
       end
 
       it "raises an exception if topic is nil" do
         expect {
-          subject.publish(exchange, nil, "some body")
+          described_class.new(options).publish(exchange, nil, "some body")
         }.to raise_exception(RuntimeError, "Topic cannot be nil")
       end
 
       it "raises an exception if body is nil" do
         expect {
-          subject.publish(exchange, "#", nil)
+          described_class.new(options).publish(exchange, "#", nil)
         }.to raise_exception(RuntimeError, "Message body cannot be nil")
       end
     end
 
     it "allows publishing against an exchange" do
-      expect(subject.publish(exchange, "#", "some body"))
+      expect(described_class.new(options).publish(exchange, "#", "some body"))
         .not_to be_nil
     end
   end

--- a/spec/govuk_seed_crawler/amqp_client_spec.rb
+++ b/spec/govuk_seed_crawler/amqp_client_spec.rb
@@ -28,24 +28,22 @@ describe GovukSeedCrawler::AmqpClient do
   end
 
   describe "#publish" do
-    context "error handling" do
-      it "raises an exception if exchange is nil" do
-        expect {
-          described_class.new(options).publish(nil, "#", "some body")
-        }.to raise_exception(RuntimeError, "Exchange cannot be nil")
-      end
+    it "raises an exception if exchange is nil" do
+      expect {
+        described_class.new(options).publish(nil, "#", "some body")
+      }.to raise_exception(RuntimeError, "Exchange cannot be nil")
+    end
 
-      it "raises an exception if topic is nil" do
-        expect {
-          described_class.new(options).publish(exchange, nil, "some body")
-        }.to raise_exception(RuntimeError, "Topic cannot be nil")
-      end
+    it "raises an exception if topic is nil" do
+      expect {
+        described_class.new(options).publish(exchange, nil, "some body")
+      }.to raise_exception(RuntimeError, "Topic cannot be nil")
+    end
 
-      it "raises an exception if body is nil" do
-        expect {
-          described_class.new(options).publish(exchange, "#", nil)
-        }.to raise_exception(RuntimeError, "Message body cannot be nil")
-      end
+    it "raises an exception if body is nil" do
+      expect {
+        described_class.new(options).publish(exchange, "#", nil)
+      }.to raise_exception(RuntimeError, "Message body cannot be nil")
     end
 
     it "allows publishing against an exchange" do

--- a/spec/govuk_seed_crawler/amqp_client_spec.rb
+++ b/spec/govuk_seed_crawler/amqp_client_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe GovukSeedCrawler::AmqpClient do
   let(:exchange) { "govuk_seed_crawler_spec_exchange" }
   let(:options) do

--- a/spec/govuk_seed_crawler/amqp_client_spec.rb
+++ b/spec/govuk_seed_crawler/amqp_client_spec.rb
@@ -1,13 +1,16 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe GovukSeedCrawler::AmqpClient do
+  subject { described_class.new(options) }
+
   let(:exchange) { "govuk_seed_crawler_spec_exchange" }
-  let(:options) {{
-    :host => ENV.fetch("AMQP_HOST", "localhost"),
-    :user => ENV.fetch("AMQP_USER", "govuk_seed_crawler"),
-    :pass => ENV.fetch("AMQP_PASS", "govuk_seed_crawler"),
-  }}
-  subject { GovukSeedCrawler::AmqpClient.new(options) }
+  let(:options) do
+    {
+      host: ENV.fetch("AMQP_HOST", "localhost"),
+      user: ENV.fetch("AMQP_USER", "govuk_seed_crawler"),
+      pass: ENV.fetch("AMQP_PASS", "govuk_seed_crawler"),
+    }
+  end
 
   it "responds to #channel" do
     expect(subject).to respond_to(:channel)
@@ -19,14 +22,14 @@ describe GovukSeedCrawler::AmqpClient do
 
   it "closes the connection to the AMQP server" do
     mock_bunny = double(:mock_bunny,
-      :start => true, :create_channel => true, :close => true)
+                        start: true, create_channel: true, close: true)
     allow(Bunny).to receive(:new).and_return(mock_bunny)
     expect(mock_bunny).to receive(:close).once
 
     subject.close
   end
 
-  context "#publish" do
+  describe "#publish" do
     context "error handling" do
       it "raises an exception if exchange is nil" do
         expect {
@@ -49,7 +52,7 @@ describe GovukSeedCrawler::AmqpClient do
 
     it "allows publishing against an exchange" do
       expect(subject.publish(exchange, "#", "some body"))
-        .to_not be_nil
+        .not_to be_nil
     end
   end
 end

--- a/spec/govuk_seed_crawler/cli_parser_spec.rb
+++ b/spec/govuk_seed_crawler/cli_parser_spec.rb
@@ -1,28 +1,28 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe GovukSeedCrawler::CLIParser do
   it "requires the site_root to be provided" do
     expect {
-      GovukSeedCrawler::CLIParser.new([]).parse
+      described_class.new([]).parse
     }.to raise_exception(GovukSeedCrawler::CLIException, "site_root must be provided")
   end
 
   it "provides the defaults when just given the site_root" do
-    options, site_root = GovukSeedCrawler::CLIParser.new(["https://www.example.com"]).parse
+    options, site_root = described_class.new(["https://www.example.com"]).parse
 
     expect(options).to eq(GovukSeedCrawler::CLIParser::DEFAULTS)
     expect(site_root).to eq("https://www.example.com")
   end
 
-  it "should tell us when we've given too many arguments" do
+  it "tells us when we've given too many arguments" do
     expect {
-      GovukSeedCrawler::CLIParser.new(["a", "b"]).parse
+      described_class.new(%w[a b]).parse
     }.to raise_exception(GovukSeedCrawler::CLIException, "too many arguments provided")
   end
 
-  it "should nest the help message in with any CLIExceptions we raise" do
+  it "nests the help message in with any CLIExceptions we raise" do
     expect {
-      GovukSeedCrawler::CLIParser.new(["a", "b"]).parse
+      described_class.new(%w[a b]).parse
     }.to raise_exception(GovukSeedCrawler::CLIException) { |e|
       expect(e.help).to include("Usage: ")
     }
@@ -31,36 +31,36 @@ describe GovukSeedCrawler::CLIParser do
   describe "catching STDOUT" do
     it "shows the help banner when provided -h" do
       # Get a valid options response as help closes early with SystemExit.
-      options = GovukSeedCrawler::CLIParser.new(["http://www.foo.com/"]).options
+      options = described_class.new(["http://www.foo.com/"]).options
 
-      expect { GovukSeedCrawler::CLIParser.new(["-h"]).parse }
-        .to output(options.help + "\n").to_stdout
+      expect { described_class.new(["-h"]).parse }
+        .to output("#{options.help}\n").to_stdout
         .and raise_exception(SystemExit) { |e| expect(e.status).to eq(0) }
     end
 
-    it "should show the version number and exit" do
-      expect { GovukSeedCrawler::CLIParser.new(["--version"]).parse }
+    it "shows the version number and exit" do
+      expect { described_class.new(["--version"]).parse }
         .to output("Version: #{GovukSeedCrawler::VERSION}\n").to_stdout
         .and raise_exception(SystemExit) { |e| expect(e.status).to eq(0) }
     end
   end
 
   describe "passing in valid arguments" do
-    let(:arguments) {
+    let(:arguments) do
       [
-       "https://www.override.com/",
-       "--host rabbitmq.some.custom.vhost",
-       "--port 4567",
-       "--username foo",
-       "--password bar",
-       "--exchange some_custom_exchange",
-       "--topic some_custom_topic",
-       "--vhost a_vhost",
-       "--verbose"
+        "https://www.override.com/",
+        "--host rabbitmq.some.custom.vhost",
+        "--port 4567",
+        "--username foo",
+        "--password bar",
+        "--exchange some_custom_exchange",
+        "--topic some_custom_topic",
+        "--vhost a_vhost",
+        "--verbose",
       ].join(" ").split(" ")
-    }
+    end
 
-    it "should override all of the default arguments that we're providing" do
+    it "overrides all of the default arguments that we're providing" do
       overriden = {
         host: "rabbitmq.some.custom.vhost",
         port: "4567",
@@ -72,14 +72,14 @@ describe GovukSeedCrawler::CLIParser do
         quiet: false,
         verbose: true,
         version: nil,
-        vhost: "a_vhost"
+        vhost: "a_vhost",
       }
 
-      expect(GovukSeedCrawler::CLIParser.new(arguments).parse.first).to eq(overriden)
+      expect(described_class.new(arguments).parse.first).to eq(overriden)
     end
 
-    it "should set the --quiet value" do
-      options, _ = GovukSeedCrawler::CLIParser.new(["foo.com", "--quiet"]).parse
+    it "sets the --quiet value" do
+      options, = described_class.new(["foo.com", "--quiet"]).parse
       expect(options).to eq(GovukSeedCrawler::CLIParser::DEFAULTS.merge(quiet: true))
     end
 
@@ -95,14 +95,14 @@ describe GovukSeedCrawler::CLIParser do
       it "sets the password if set using an environment variable" do
         set_amqp_pass("foobar")
 
-        expect(GovukSeedCrawler::CLIParser.new(["http://www.example.com"]).parse.first)
+        expect(described_class.new(["http://www.example.com"]).parse.first)
           .to include(password: "foobar")
       end
 
       it "picks the environment variable over the parameter if both are set" do
         set_amqp_pass("bar")
 
-        expect(GovukSeedCrawler::CLIParser.new(["http://www.example.com", "--password", "foo"]).parse.first)
+        expect(described_class.new(["http://www.example.com", "--password", "foo"]).parse.first)
           .to include(password: "bar")
       end
     end

--- a/spec/govuk_seed_crawler/cli_parser_spec.rb
+++ b/spec/govuk_seed_crawler/cli_parser_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe GovukSeedCrawler::CLIParser do
   it "requires the site_root to be provided" do
     expect {

--- a/spec/govuk_seed_crawler/cli_parser_spec.rb
+++ b/spec/govuk_seed_crawler/cli_parser_spec.rb
@@ -33,27 +33,15 @@ describe GovukSeedCrawler::CLIParser do
       # Get a valid options response as help closes early with SystemExit.
       options = GovukSeedCrawler::CLIParser.new(["http://www.foo.com/"]).options
 
-      temp_stdout do |caught_stdout|
-        expect {
-          _, _ = GovukSeedCrawler::CLIParser.new(["-h"]).parse
-        }.to raise_exception(SystemExit) { |e|
-          expect(e.status).to eq(0)
-        }
-
-        expect(caught_stdout.strip).to eq(options.help)
-      end
+      expect { GovukSeedCrawler::CLIParser.new(["-h"]).parse }
+        .to output(options.help + "\n").to_stdout
+        .and raise_exception(SystemExit) { |e| expect(e.status).to eq(0) }
     end
 
     it "should show the version number and exit" do
-      temp_stdout do |caught_stdout|
-        expect {
-          _, _ = GovukSeedCrawler::CLIParser.new(["--version"]).parse
-        }.to raise_exception(SystemExit) { |e|
-          expect(e.status).to eq(0)
-        }
-
-        expect(caught_stdout.strip).to eq("Version: #{GovukSeedCrawler::VERSION}")
-      end
+      expect { GovukSeedCrawler::CLIParser.new(["--version"]).parse }
+        .to output("Version: #{GovukSeedCrawler::VERSION}\n").to_stdout
+        .and raise_exception(SystemExit) { |e| expect(e.status).to eq(0) }
     end
   end
 

--- a/spec/govuk_seed_crawler/cli_runner_spec.rb
+++ b/spec/govuk_seed_crawler/cli_runner_spec.rb
@@ -5,41 +5,23 @@ describe GovukSeedCrawler::CLIRunner do
     it "should not try to connect to an AMQP server" do
       expect(Bunny).not_to receive(:new)
 
-      temp_stdout do |caught_stdout|
-        expect {
-          GovukSeedCrawler::CLIRunner.new(["--version"]).run
-        }.to raise_exception(SystemExit) { |exit|
-          expect(exit.status).to eq(0)
-        }
-
-        expect(caught_stdout.strip).to eq("Version: #{GovukSeedCrawler::VERSION}")
-      end
+      expect { GovukSeedCrawler::CLIRunner.new(["--version"]).run }
+        .to output("Version: #{GovukSeedCrawler::VERSION}\n").to_stdout
+        .and raise_exception(SystemExit) { |e| expect(e.status).to eq(0) }
     end
   end
 
   describe "catching any CLIException objects and exiting with a status 1" do
     it "prints to STDOUT for too many arguments" do
-      temp_stdout do |caught_stdout|
-        expect {
-          GovukSeedCrawler::CLIRunner.new(["a", "b"])
-        }.to raise_exception(SystemExit) { |exit|
-          expect(exit.status).to eq(2)
-        }
-
-        expect(caught_stdout.strip).to include("too many arguments provided")
-      end
+      expect { GovukSeedCrawler::CLIRunner.new(["a", "b"]).run }
+        .to output(/\Atoo many arguments provided/).to_stdout
+        .and raise_exception(SystemExit) { |e| expect(e.status).to eq(2) }
     end
 
     it "prints to STDOUT when site_root not set" do
-      temp_stdout do |caught_stdout|
-        expect {
-          GovukSeedCrawler::CLIRunner.new(["--verbose"])
-        }.to raise_exception(SystemExit) { |exit|
-          expect(exit.status).to eq(2)
-        }
-
-        expect(caught_stdout.strip).to include("site_root must be provided")
-      end
+      expect { GovukSeedCrawler::CLIRunner.new(["--verbose"]).run }
+        .to output(/\Asite_root must be provided/).to_stdout
+        .and raise_exception(SystemExit) { |e| expect(e.status).to eq(2) }
     end
   end
 

--- a/spec/govuk_seed_crawler/cli_runner_spec.rb
+++ b/spec/govuk_seed_crawler/cli_runner_spec.rb
@@ -1,11 +1,11 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe GovukSeedCrawler::CLIRunner do
   describe "printing the version" do
-    it "should not try to connect to an AMQP server" do
+    it "does not try to connect to an AMQP server" do
       expect(Bunny).not_to receive(:new)
 
-      expect { GovukSeedCrawler::CLIRunner.new(["--version"]).run }
+      expect { described_class.new(["--version"]).run }
         .to output("Version: #{GovukSeedCrawler::VERSION}\n").to_stdout
         .and raise_exception(SystemExit) { |e| expect(e.status).to eq(0) }
     end
@@ -13,13 +13,13 @@ describe GovukSeedCrawler::CLIRunner do
 
   describe "catching any CLIException objects and exiting with a status 1" do
     it "prints to STDOUT for too many arguments" do
-      expect { GovukSeedCrawler::CLIRunner.new(["a", "b"]).run }
+      expect { described_class.new(%w[a b]).run }
         .to output(/\Atoo many arguments provided/).to_stdout
         .and raise_exception(SystemExit) { |e| expect(e.status).to eq(2) }
     end
 
     it "prints to STDOUT when site_root not set" do
-      expect { GovukSeedCrawler::CLIRunner.new(["--verbose"]).run }
+      expect { described_class.new(["--verbose"]).run }
         .to output(/\Asite_root must be provided/).to_stdout
         .and raise_exception(SystemExit) { |e| expect(e.status).to eq(2) }
     end
@@ -31,26 +31,26 @@ describe GovukSeedCrawler::CLIRunner do
     end
 
     it "defaults to INFO" do
-      GovukSeedCrawler::CLIRunner.new(["http://www.example.com"])
+      described_class.new(["http://www.example.com"])
       expect(GovukSeedCrawler.logger.level).to eq(Logger::INFO)
     end
 
     it "sets to ERROR for quite" do
-      GovukSeedCrawler::CLIRunner.new(["http://www.example.com", "--quiet"])
+      described_class.new(["http://www.example.com", "--quiet"])
       expect(GovukSeedCrawler.logger.level).to eq(Logger::ERROR)
     end
 
     it "sets to DEBUG for verbose" do
-      GovukSeedCrawler::CLIRunner.new(["http://www.example.com", "--verbose"])
+      described_class.new(["http://www.example.com", "--verbose"])
       expect(GovukSeedCrawler.logger.level).to eq(Logger::DEBUG)
     end
   end
 
   describe "#run" do
     it "passes all options through to seed" do
-      expect(GovukSeedCrawler::Seeder).to receive(:seed).
-        with("http://www.example.com", GovukSeedCrawler::CLIParser::DEFAULTS).once
-      GovukSeedCrawler::CLIRunner.new(["http://www.example.com"]).run
+      expect(GovukSeedCrawler::Seeder).to receive(:seed)
+        .with("http://www.example.com", GovukSeedCrawler::CLIParser::DEFAULTS).once
+      described_class.new(["http://www.example.com"]).run
     end
   end
 end

--- a/spec/govuk_seed_crawler/cli_runner_spec.rb
+++ b/spec/govuk_seed_crawler/cli_runner_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe GovukSeedCrawler::CLIRunner do
   describe "printing the version" do
     it "does not try to connect to an AMQP server" do

--- a/spec/govuk_seed_crawler/indexer_spec.rb
+++ b/spec/govuk_seed_crawler/indexer_spec.rb
@@ -1,19 +1,17 @@
 require "spec_helper"
 
 describe GovukSeedCrawler::Indexer do
-  context "under normal usage" do
-    let(:mock_parser) do
-      double(:mock_parser, to_a: [])
-    end
+  let(:mock_parser) do
+    double(:mock_parser, to_a: [])
+  end
 
-    it "responds to Indexer#urls" do
-      allow(SitemapParser).to receive(:new).and_return(mock_parser)
-      expect(described_class.new("https://example.com")).to respond_to(:urls)
-    end
+  it "responds to Indexer#urls" do
+    allow(SitemapParser).to receive(:new).and_return(mock_parser)
+    expect(described_class.new("https://example.com")).to respond_to(:urls)
+  end
 
-    it "calls SitemapParser with the sitemap file" do
-      expect(SitemapParser).to receive(:new).with("https://example.com/sitemap.xml", { recurse: true }).and_return(mock_parser)
-      described_class.new("https://example.com")
-    end
+  it "calls SitemapParser with the sitemap file" do
+    expect(SitemapParser).to receive(:new).with("https://example.com/sitemap.xml", { recurse: true }).and_return(mock_parser)
+    described_class.new("https://example.com")
   end
 end

--- a/spec/govuk_seed_crawler/indexer_spec.rb
+++ b/spec/govuk_seed_crawler/indexer_spec.rb
@@ -5,12 +5,16 @@ describe GovukSeedCrawler::Indexer do
 
   it "responds to Indexer#urls" do
     allow(SitemapParser).to receive(:new).and_return(mock_parser)
-    expect(described_class.new("https://example.com")).to respond_to(:urls)
+    instance = nil
+    expect { instance = described_class.new("https://example.com") }
+      .to output.to_stdout
+    expect(instance).to respond_to(:urls)
   end
 
   it "calls SitemapParser with the sitemap file" do
     allow(SitemapParser).to receive(:new).with("https://example.com/sitemap.xml", { recurse: true }).and_return(mock_parser)
-    described_class.new("https://example.com")
+    expect { described_class.new("https://example.com") }
+      .to output.to_stdout
     expect(SitemapParser).to have_received(:new)
   end
 end

--- a/spec/govuk_seed_crawler/indexer_spec.rb
+++ b/spec/govuk_seed_crawler/indexer_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe GovukSeedCrawler::Indexer do
-  subject { described_class.new("https://example.com") }
-
   context "under normal usage" do
     let(:mock_parser) do
       double(:mock_parser, to_a: [])
@@ -10,12 +8,12 @@ describe GovukSeedCrawler::Indexer do
 
     it "responds to Indexer#urls" do
       allow(SitemapParser).to receive(:new).and_return(mock_parser)
-      expect(subject).to respond_to(:urls)
+      expect(described_class.new("https://example.com")).to respond_to(:urls)
     end
 
     it "calls SitemapParser with the sitemap file" do
       expect(SitemapParser).to receive(:new).with("https://example.com/sitemap.xml", { recurse: true }).and_return(mock_parser)
-      subject
+      described_class.new("https://example.com")
     end
   end
 end

--- a/spec/govuk_seed_crawler/indexer_spec.rb
+++ b/spec/govuk_seed_crawler/indexer_spec.rb
@@ -1,11 +1,11 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe GovukSeedCrawler::Indexer do
-  subject { GovukSeedCrawler::Indexer.new('https://example.com') }
+  subject { described_class.new("https://example.com") }
 
   context "under normal usage" do
     let(:mock_parser) do
-      double(:mock_parser, :to_a => [])
+      double(:mock_parser, to_a: [])
     end
 
     it "responds to Indexer#urls" do
@@ -14,7 +14,7 @@ describe GovukSeedCrawler::Indexer do
     end
 
     it "calls SitemapParser with the sitemap file" do
-      expect(SitemapParser).to receive(:new).with('https://example.com/sitemap.xml', {:recurse => true}).and_return(mock_parser)
+      expect(SitemapParser).to receive(:new).with("https://example.com/sitemap.xml", { recurse: true }).and_return(mock_parser)
       subject
     end
   end

--- a/spec/govuk_seed_crawler/indexer_spec.rb
+++ b/spec/govuk_seed_crawler/indexer_spec.rb
@@ -1,9 +1,7 @@
 require "spec_helper"
 
 describe GovukSeedCrawler::Indexer do
-  let(:mock_parser) do
-    double(:mock_parser, to_a: [])
-  end
+  let(:mock_parser) { instance_double(SitemapParser, to_a: []) }
 
   it "responds to Indexer#urls" do
     allow(SitemapParser).to receive(:new).and_return(mock_parser)

--- a/spec/govuk_seed_crawler/indexer_spec.rb
+++ b/spec/govuk_seed_crawler/indexer_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe GovukSeedCrawler::Indexer do
   let(:mock_parser) { instance_double(SitemapParser, to_a: []) }
 

--- a/spec/govuk_seed_crawler/indexer_spec.rb
+++ b/spec/govuk_seed_crawler/indexer_spec.rb
@@ -11,7 +11,8 @@ describe GovukSeedCrawler::Indexer do
   end
 
   it "calls SitemapParser with the sitemap file" do
-    expect(SitemapParser).to receive(:new).with("https://example.com/sitemap.xml", { recurse: true }).and_return(mock_parser)
+    allow(SitemapParser).to receive(:new).with("https://example.com/sitemap.xml", { recurse: true }).and_return(mock_parser)
     described_class.new("https://example.com")
+    expect(SitemapParser).to have_received(:new)
   end
 end

--- a/spec/govuk_seed_crawler/seeder_spec.rb
+++ b/spec/govuk_seed_crawler/seeder_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe GovukSeedCrawler::Seeder do
-  subject { described_class.seed(root_url, options) }
-
   let(:exchange) { "seeder_test_exchange" }
   let(:topic) { "#" }
   let(:root_url) { "https://www.example.com" }
@@ -41,13 +39,13 @@ describe GovukSeedCrawler::Seeder do
           .with(exchange, topic, url)
       end
 
-      subject
+      described_class.seed(root_url, options)
     end
 
     it "closes the connection when done" do
       allow(mock_amqp_client).to receive(:publish)
       expect(mock_amqp_client).to receive(:close)
-      subject
+      described_class.seed(root_url, options)
     end
   end
 end

--- a/spec/govuk_seed_crawler/seeder_spec.rb
+++ b/spec/govuk_seed_crawler/seeder_spec.rb
@@ -32,20 +32,18 @@ describe GovukSeedCrawler::Seeder do
       .with(options).and_return(mock_amqp_client)
   end
 
-  context "under normal usage" do
-    it "publishes urls to the queue" do
-      urls.each do |url|
-        expect(mock_amqp_client).to receive(:publish)
-          .with(exchange, topic, url)
-      end
-
-      described_class.seed(root_url, options)
+  it "publishes urls to the queue" do
+    urls.each do |url|
+      expect(mock_amqp_client).to receive(:publish)
+        .with(exchange, topic, url)
     end
 
-    it "closes the connection when done" do
-      allow(mock_amqp_client).to receive(:publish)
-      expect(mock_amqp_client).to receive(:close)
-      described_class.seed(root_url, options)
-    end
+    described_class.seed(root_url, options)
+  end
+
+  it "closes the connection when done" do
+    allow(mock_amqp_client).to receive(:publish)
+    expect(mock_amqp_client).to receive(:close)
+    described_class.seed(root_url, options)
   end
 end

--- a/spec/govuk_seed_crawler/seeder_spec.rb
+++ b/spec/govuk_seed_crawler/seeder_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe GovukSeedCrawler::Seeder do
   let(:exchange) { "seeder_test_exchange" }
   let(:topic) { "#" }

--- a/spec/govuk_seed_crawler/seeder_spec.rb
+++ b/spec/govuk_seed_crawler/seeder_spec.rb
@@ -1,29 +1,31 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe GovukSeedCrawler::Seeder do
+  subject { described_class.seed(root_url, options) }
+
   let(:exchange) { "seeder_test_exchange" }
   let(:topic) { "#" }
   let(:root_url) { "https://www.example.com" }
 
-  let(:options) {{
-    :exchange => exchange,
-    :topic => topic,
-  }}
+  let(:options) do
+    {
+      exchange: exchange,
+      topic: topic,
+    }
+  end
 
-  let(:mock_get_urls) { double(:mock_get_urls, :urls => true) }
-  let(:mock_amqp_client) { double(:mock_amqp_client, :close => true) }
+  let(:mock_get_urls) { double(:mock_get_urls, urls: true) }
+  let(:mock_amqp_client) { double(:mock_amqp_client, close: true) }
 
   let(:urls) do
     [
-     "https://example.com/foo",
-     "https://example.com/bar",
-     "https://example.com/baz",
+      "https://example.com/foo",
+      "https://example.com/bar",
+      "https://example.com/baz",
     ]
   end
 
-  subject { GovukSeedCrawler::Seeder::seed(root_url, options) }
-
-  before(:each) do
+  before do
     allow(GovukSeedCrawler::Indexer).to receive(:new)
       .with(root_url)
       .and_return(mock_get_urls)

--- a/spec/govuk_seed_crawler/seeder_spec.rb
+++ b/spec/govuk_seed_crawler/seeder_spec.rb
@@ -12,8 +12,8 @@ describe GovukSeedCrawler::Seeder do
     }
   end
 
-  let(:mock_get_urls) { double(:mock_get_urls, urls: true) }
-  let(:mock_amqp_client) { double(:mock_amqp_client, close: true) }
+  let(:mock_get_urls) { instance_double(GovukSeedCrawler::Indexer, urls: true) }
+  let(:mock_amqp_client) { instance_double(GovukSeedCrawler::AmqpClient, close: true) }
 
   let(:urls) do
     [

--- a/spec/govuk_seed_crawler/seeder_spec.rb
+++ b/spec/govuk_seed_crawler/seeder_spec.rb
@@ -38,12 +38,14 @@ describe GovukSeedCrawler::Seeder do
         .with(exchange, topic, url)
     end
 
-    described_class.seed(root_url, options)
+    expect { described_class.seed(root_url, options) }
+      .to output.to_stdout
   end
 
   it "closes the connection when done" do
     allow(mock_amqp_client).to receive(:publish)
     expect(mock_amqp_client).to receive(:close)
-    described_class.seed(root_url, options)
+    expect { described_class.seed(root_url, options) }
+      .to output.to_stdout
   end
 end

--- a/spec/integration/govuk_seed_crawler_spec.rb
+++ b/spec/integration/govuk_seed_crawler_spec.rb
@@ -1,5 +1,4 @@
 require "json"
-require "spec_helper"
 
 describe GovukSeedCrawler do
   def stub_sitemap

--- a/spec/integration/govuk_seed_crawler_spec.rb
+++ b/spec/integration/govuk_seed_crawler_spec.rb
@@ -52,7 +52,8 @@ describe GovukSeedCrawler do
 
   it "publishes URLs it finds to an AMQP topic exchange" do
     stub_sitemap
-    GovukSeedCrawler::Seeder.seed(site_root, options)
+    expect { GovukSeedCrawler::Seeder.seed(site_root, options) }
+      .to output.to_stdout
 
     expect(queue.message_count).to be(3)
   end

--- a/spec/integration/govuk_seed_crawler_spec.rb
+++ b/spec/integration/govuk_seed_crawler_spec.rb
@@ -54,7 +54,7 @@ describe GovukSeedCrawler do
 
   it "publishes URLs it finds to an AMQP topic exchange" do
     stub_sitemap
-    subject
+    GovukSeedCrawler::Seeder.seed(site_root, options)
 
     expect(@queue.message_count).to be(3)
   end

--- a/spec/integration/govuk_seed_crawler_spec.rb
+++ b/spec/integration/govuk_seed_crawler_spec.rb
@@ -1,9 +1,9 @@
-require 'json'
-require 'spec_helper'
+require "json"
+require "spec_helper"
 
 describe GovukSeedCrawler do
   def stub_sitemap
-    sitemap = %{<?xml version="1.0" encoding="UTF-8"?>
+    sitemap = %(<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.gov.uk/</loc>
@@ -15,35 +15,37 @@ describe GovukSeedCrawler do
     <loc>https://www.gov.uk/help</loc>
   </url>
 </urlset>
-    }
+    )
 
-    stub_request(:get, "https://www.gov.uk/sitemap.xml").
-         to_return(:status => 200, :body => sitemap, :headers => {})
+    stub_request(:get, "https://www.gov.uk/sitemap.xml")
+         .to_return(status: 200, body: sitemap, headers: {})
   end
+
+  subject { GovukSeedCrawler::Seeder.seed(site_root, options) }
 
   let(:vhost) { "/" }
   let(:exchange_name) { "govuk_seed_crawler_integration_exchange" }
   let(:queue_name) { "govuk_seed_crawler_integration_queue" }
   let(:topic) { "#" }
   let(:site_root) { "https://www.gov.uk" }
-  let(:options) {{
-      :host => ENV.fetch("AMQP_HOST", "localhost"),
-      :user => ENV.fetch("AMQP_USER", "govuk_seed_crawler"),
-      :pass => ENV.fetch("AMQP_PASS", "govuk_seed_crawler"),
-      :exchange => exchange_name,
-      :topic => topic
-  }}
+  let(:options) do
+    {
+      host: ENV.fetch("AMQP_HOST", "localhost"),
+      user: ENV.fetch("AMQP_USER", "govuk_seed_crawler"),
+      pass: ENV.fetch("AMQP_PASS", "govuk_seed_crawler"),
+      exchange: exchange_name,
+      topic: topic,
+    }
+  end
   let(:rabbitmq_client) { GovukSeedCrawler::AmqpClient.new(options) }
 
-  subject { GovukSeedCrawler::Seeder::seed(site_root, options) }
-
-  before(:each) do
-    @exchange = rabbitmq_client.channel.topic(exchange_name, :durable => true)
+  before do
+    @exchange = rabbitmq_client.channel.topic(exchange_name, durable: true)
     @queue = rabbitmq_client.channel.queue(queue_name)
-    @queue.bind(@exchange, :routing_key => topic)
+    @queue.bind(@exchange, routing_key: topic)
   end
 
-  after(:each) do
+  after do
     @queue.unbind(@exchange)
     @queue.delete
     @exchange.delete

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require 'govuk_seed_crawler'
-require 'webmock/rspec'
+require "govuk_seed_crawler"
+require "webmock/rspec"
 
 WebMock.disable_net_connect!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,10 +30,3 @@ RSpec.configure do |config|
 end
 
 WebMock.disable_net_connect!
-
-def temp_stdout
-  $stdout = StringIO.new
-  yield $stdout.string
-ensure
-  $stdout = STDOUT
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'govuk_seed_crawler'
 require 'webmock/rspec'
 
+WebMock.disable_net_connect!
+
 RSpec.configure do |config|
   config.order = :random
 
@@ -28,5 +30,3 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 end
-
-WebMock.disable_net_connect!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,4 +29,9 @@ RSpec.configure do |config|
     # a real object. This is generally recommended.
     mocks.verify_partial_doubles = true
   end
+
+  config.before do
+    # reset logger before each invocation so we can catch stdout
+    GovukSeedCrawler.logger = nil
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

This adds a bunch of basic enhancements to this repo prior to switching the CI and release process to use GitHub Actions. It does things like: conventional licence, fixes tests outputting to stdout and adds linting.

It also changes the version constraint to be more normal of a gem and use a optimistic constraint of greater than equal to Ruby 2.7 rather than the previous pessimistic constraint on Ruby 2.6 (which presumably means https://github.com/alphagov/govuk_seed_crawler/commit/cde37174cc31a3656d9f32e475f0eecc2273621c had no effect).

This is best reviewed commit by commit