### PR TITLE
Bump to version 3.1.0

### DIFF
--- a/lib/govuk_seed_crawler/version.rb
+++ b/lib/govuk_seed_crawler/version.rb
@@ -1,3 +1,3 @@
 module GovukSeedCrawler
-  VERSION = "3.0.0".freeze
+  VERSION = "3.1.0".freeze
 end


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

This only includes the change to require a non-EOL Ruby version for users, though does release some cleanup and verifies the GitHub action release works