### PR TITLE
Bump to version 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
-## Unreleased
+## 3.2.0
 
-- Drop support for Ruby < 2.7
+- Drop support for Ruby < 2.7 ([#23](https://github.com/alphagov/govuk_seed_crawler/pull/23))
+- Update major version of 'Slop' dependency ([#17](https://github.com/alphagov/govuk_seed_crawler/pull/17))

--- a/lib/govuk_seed_crawler/version.rb
+++ b/lib/govuk_seed_crawler/version.rb
@@ -1,3 +1,3 @@
 module GovukSeedCrawler
-  VERSION = "3.1.0".freeze
+  VERSION = "3.2.0".freeze
 end


### PR DESCRIPTION
Slop dependency update would be a patch update (even though it was a pretty hefty change internally), but dropping support for Ruby 2.7 is something of a breaking change. But opted for a minor version update rather than a major version, as the API for govuk_seed_crawler hasn't changed.