### PR TITLE
Update Slop dependency to >= 4.0

### DIFF
--- a/govuk_seed_crawler.gemspec
+++ b/govuk_seed_crawler.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   # public_suffix > 1.5 requires ruby > 2.
   spec.add_runtime_dependency "public_suffix", ">= 1.4.6", "< 5.1.0"
   spec.add_runtime_dependency "sitemap-parser", ">= 0.3", "< 0.6"
-  spec.add_runtime_dependency "slop", ">= 3.6", "< 4.11"
+  spec.add_runtime_dependency "slop", ">= 4.0", "< 4.11"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
[Trello card](https://trello.com/c/YYBhibdh/3112-check-if-govuk-crawler-is-broken-and-fix-it-if-so)

Since dd88b5580bcbd5ec8a83913ea07190f391451514 this gem no longer supports Slop v3, but we haven't updated our gemspec to reflect this. As a result, in production we're still trying to run against Slop 3.6.0, which is causing the following error:

```
/usr/lib/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/govuk_seed_crawler-3.2.0/lib/govuk_seed_crawler/cli_parser.rb:33:in `options': uninitialized constant Slop::Options (NameError)

      opts = Slop::Options.new
                 ^^^^^^^^^
	from /usr/lib/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/govuk_seed_crawler-3.2.0/lib/govuk_seed_crawler/cli_parser.rb:68:in `parse'
	from /usr/lib/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/govuk_seed_crawler-3.2.0/lib/govuk_seed_crawler/cli_runner.rb:5:in `initialize'
	from /usr/lib/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/govuk_seed_crawler-3.2.0/bin/seed-crawler:5:in `new'
	from /usr/lib/rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/govuk_seed_crawler-3.2.0/bin/seed-crawler:5:in `<top (required)>'
	from /usr/local/bin/seed-crawler:25:in `load'
	from /usr/local/bin/seed-crawler:25:in `<main>'
```