### PR TITLE
Bump to version 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 3.2.1
+
+- Update minimum Slop requirement from 3.6 to 4.0 ([#38](https://github.com/alphagov/govuk_seed_crawler/pull/38))
+
 ## 3.2.0
 
 - Drop support for Ruby < 2.7 ([#23](https://github.com/alphagov/govuk_seed_crawler/pull/23))

--- a/lib/govuk_seed_crawler/version.rb
+++ b/lib/govuk_seed_crawler/version.rb
@@ -1,3 +1,3 @@
 module GovukSeedCrawler
-  VERSION = "3.2.0".freeze
+  VERSION = "3.2.1".freeze
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/YYBhibdh/3112-check-if-govuk-crawler-is-broken-and-fix-it-if-so)

This is a bugfix that does not change the external interface of the tool, so I think a patch-level bump is appropriate.

Although we are bumping a dependency by a major version, this gem is intended to be used as an executable rather than as a library, and so I don't think this constitutes a breaking change.